### PR TITLE
feat: make initialize params optional

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -34,7 +34,7 @@ export default class App {
     overrideHandlers = {},
     loggingService,
     ...custom
-  }) {
+  } = {}) {
     try {
       await this.override(handlers.beforeInit, overrideHandlers.beforeInit);
       PubSub.publish(APP_BEFORE_INIT);
@@ -48,6 +48,10 @@ export default class App {
       await this.override(handlers.configuration, overrideHandlers.configuration);
       PubSub.publish(APP_CONFIGURED);
 
+      // Logging
+      await this.override(handlers.logging, overrideHandlers.logging);
+      PubSub.publish(APP_LOGGING_CONFIGURED);
+
       // Authentication
       await this.override(handlers.authentication, overrideHandlers.authentication);
       PubSub.publish(APP_AUTHENTICATED);
@@ -55,10 +59,6 @@ export default class App {
       // Internationalization
       await this.override(handlers.i18n, overrideHandlers.i18n);
       PubSub.publish(APP_I18N_CONFIGURED);
-
-      // Logging
-      await this.override(handlers.logging, overrideHandlers.logging);
-      PubSub.publish(APP_LOGGING_CONFIGURED);
 
       // Analytics
       await this.override(handlers.analytics, overrideHandlers.analytics);

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -97,7 +97,7 @@ describe('App', () => {
       App.subscribe(APP_BEFORE_READY, checkDispatchedDone);
       App.subscribe(APP_READY, checkDispatchedDone);
 
-      await App.initialize({ messages: null, loggingService: 'logging service' });
+      await App.initialize();
 
       expect(analytics).toHaveBeenCalledWith(App);
       expect(authentication).toHaveBeenCalledWith(App);
@@ -168,6 +168,7 @@ describe('App', () => {
       // All of these.
       expect(beforeInit).toHaveBeenCalledWith(App);
       expect(configuration).toHaveBeenCalledWith(App);
+      expect(logging).toHaveBeenCalledWith(App);
       expect(overrideHandlers.authentication).toHaveBeenCalledWith(App);
 
       // None of these.
@@ -175,7 +176,6 @@ describe('App', () => {
       expect(authentication).not.toHaveBeenCalled();
       expect(beforeReady).not.toHaveBeenCalled();
       expect(i18n).not.toHaveBeenCalled();
-      expect(logging).not.toHaveBeenCalled();
       expect(ready).not.toHaveBeenCalled();
 
       // Hey, an error!
@@ -205,6 +205,7 @@ describe('App', () => {
       // All of these.
       expect(beforeInit).toHaveBeenCalledWith(App);
       expect(configuration).toHaveBeenCalledWith(App);
+      expect(logging).toHaveBeenCalledWith(App);
       expect(overrideHandlers.authentication).toHaveBeenCalledWith(App);
 
       // None of these.
@@ -212,7 +213,6 @@ describe('App', () => {
       expect(authentication).not.toHaveBeenCalled();
       expect(beforeReady).not.toHaveBeenCalled();
       expect(i18n).not.toHaveBeenCalled();
-      expect(logging).not.toHaveBeenCalled();
       expect(ready).not.toHaveBeenCalled();
       // Not the default error handler.
       expect(error).not.toHaveBeenCalled();

--- a/src/handlers/error.js
+++ b/src/handlers/error.js
@@ -1,3 +1,5 @@
+import { logError } from '@edx/frontend-logging';
+
 export default async function error(app) {
-  app.loggingService.logError(app.error);
+  logError(app.error);
 }

--- a/src/handlers/error.test.js
+++ b/src/handlers/error.test.js
@@ -1,4 +1,8 @@
+import { logError } from '@edx/frontend-logging';
+
 import error from './error';
+
+jest.mock('@edx/frontend-logging');
 
 it('should log the App error', () => {
   const app = {
@@ -10,5 +14,5 @@ it('should log the App error', () => {
     },
   };
   error(app);
-  expect(app.loggingService.logError).toHaveBeenCalledWith({ message: 'oh no!' });
+  expect(logError).toHaveBeenCalledWith({ message: 'oh no!' });
 });

--- a/src/handlers/logging.js
+++ b/src/handlers/logging.js
@@ -1,5 +1,10 @@
-import { configureLoggingService } from '@edx/frontend-logging';
+import { configureLoggingService, NewRelicLoggingService } from '@edx/frontend-logging';
 
+/* eslint-disable no-param-reassign */
 export default async function logging(app) {
+  // Default to NewRelicLoggingService if one was not provided.
+  if (app.loggingService === undefined) {
+    app.loggingService = NewRelicLoggingService;
+  }
   configureLoggingService(app.loggingService);
 }

--- a/src/handlers/logging.test.js
+++ b/src/handlers/logging.test.js
@@ -6,6 +6,7 @@ import logging from './logging';
 
 jest.mock('@edx/frontend-logging', () => ({
   configureLoggingService: jest.fn(),
+  NewRelicLoggingService: 'default service',
 }));
 
 it('should configure logging with the logging service to use', () => {
@@ -14,4 +15,10 @@ it('should configure logging with the logging service to use', () => {
   };
   logging(app);
   expect(configureLoggingService).toHaveBeenCalledWith('logging service');
+});
+
+it('should configure logging with the default logging service', () => {
+  const app = {};
+  logging(app);
+  expect(configureLoggingService).toHaveBeenCalledWith('default service');
 });


### PR DESCRIPTION
Defaults loggingService to NewRelicLoggingService and configures logging sooner in the process to make sure it’s available.