### PR TITLE
fix: change name of configuration phase to loadConfig

### DIFF
--- a/docs/API.rst
+++ b/docs/API.rst
@@ -114,7 +114,7 @@ handler if provided.
 Possible keys:
 
 -  beforeInit
--  configuration
+-  loadConfig
 -  logging
 -  authentication
 -  i18n
@@ -214,11 +214,11 @@ The method returns the required config values.
    // "App configuration error: LOGIN_URL is required by MySpecialComponent."
    // if LOGIN_URL is undefined, for example.
 
-**NOTE**: If you use a custom handler for the ``configuration`` phase,
+**NOTE**: If you use a custom handler for the ``loadConfig`` phase,
 be mindful of when you call ``App.requireConfig``. Normally, environment
 variable configuration is available immediately before
 ``App.initialize`` is even called because it's statically linked into
-the app. If you load additional configuration at runtime, it won't be
+the app. If you load additional configuration at runtime (via the ``loadConfig`` phase), it won't be
 available until the ``APP_CONFIG_LOADED`` event is published:
 
 ::
@@ -423,14 +423,14 @@ want to perform actions prior to validation of the environment
 configuration, then write your code before calling ``App.initialize``
 itself.
 
-configuration
+loadConfig
 ~~~~~~~~~~~~~
 
 Event constant: ``APP_CONFIG_LOADED``
 
-The ``configuration`` phase has no default behavior.
+The ``loadConfig`` phase has no default behavior.
 
-The ``configuration`` phase can be used to provide dynamic, runtime
+The ``loadConfig`` phase can be used to provide dynamic, runtime
 configuration prior to the initialization of any other services the
 application may need.
 

--- a/src/App.js
+++ b/src/App.js
@@ -46,7 +46,7 @@ export default class App {
       this.custom = custom;
 
       // Configuration
-      await this._override(handlers.configuration, overrideHandlers.configuration);
+      await this._override(handlers.loadConfig, overrideHandlers.loadConfig);
       PubSub.publish(APP_CONFIG_LOADED);
 
       // Logging

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -6,7 +6,7 @@ import {
   authentication,
   beforeInit,
   beforeReady,
-  configuration,
+  loadConfig,
   error,
   i18n,
   logging,
@@ -59,7 +59,7 @@ describe('App', () => {
       authentication.mockClear();
       beforeInit.mockClear();
       beforeReady.mockClear();
-      configuration.mockClear();
+      loadConfig.mockClear();
       error.mockClear();
       i18n.mockClear();
       logging.mockClear();
@@ -103,7 +103,7 @@ describe('App', () => {
       expect(authentication).toHaveBeenCalledWith(App);
       expect(beforeInit).toHaveBeenCalledWith(App);
       expect(beforeReady).toHaveBeenCalledWith(App);
-      expect(configuration).toHaveBeenCalledWith(App);
+      expect(loadConfig).toHaveBeenCalledWith(App);
       expect(i18n).toHaveBeenCalledWith(App);
       expect(logging).toHaveBeenCalledWith(App);
       expect(ready).toHaveBeenCalledWith(App);
@@ -118,7 +118,7 @@ describe('App', () => {
         authentication: jest.fn(),
         beforeInit: jest.fn(),
         beforeReady: jest.fn(),
-        configuration: jest.fn(),
+        loadConfig: jest.fn(),
         i18n: jest.fn(),
         logging: jest.fn(),
         ready: jest.fn(),
@@ -134,7 +134,7 @@ describe('App', () => {
       expect(authentication).not.toHaveBeenCalled();
       expect(beforeInit).not.toHaveBeenCalled();
       expect(beforeReady).not.toHaveBeenCalled();
-      expect(configuration).not.toHaveBeenCalled();
+      expect(loadConfig).not.toHaveBeenCalled();
       expect(i18n).not.toHaveBeenCalled();
       expect(logging).not.toHaveBeenCalled();
       expect(ready).not.toHaveBeenCalled();
@@ -144,7 +144,7 @@ describe('App', () => {
       expect(overrideHandlers.authentication).toHaveBeenCalledWith(App);
       expect(overrideHandlers.beforeInit).toHaveBeenCalledWith(App);
       expect(overrideHandlers.beforeReady).toHaveBeenCalledWith(App);
-      expect(overrideHandlers.configuration).toHaveBeenCalledWith(App);
+      expect(overrideHandlers.loadConfig).toHaveBeenCalledWith(App);
       expect(overrideHandlers.i18n).toHaveBeenCalledWith(App);
       expect(overrideHandlers.logging).toHaveBeenCalledWith(App);
       expect(overrideHandlers.ready).toHaveBeenCalledWith(App);
@@ -167,7 +167,7 @@ describe('App', () => {
       });
       // All of these.
       expect(beforeInit).toHaveBeenCalledWith(App);
-      expect(configuration).toHaveBeenCalledWith(App);
+      expect(loadConfig).toHaveBeenCalledWith(App);
       expect(logging).toHaveBeenCalledWith(App);
       expect(overrideHandlers.authentication).toHaveBeenCalledWith(App);
 
@@ -204,7 +204,7 @@ describe('App', () => {
       });
       // All of these.
       expect(beforeInit).toHaveBeenCalledWith(App);
-      expect(configuration).toHaveBeenCalledWith(App);
+      expect(loadConfig).toHaveBeenCalledWith(App);
       expect(logging).toHaveBeenCalledWith(App);
       expect(overrideHandlers.authentication).toHaveBeenCalledWith(App);
 

--- a/src/handlers/configuration.js
+++ b/src/handlers/configuration.js
@@ -1,3 +1,0 @@
-export default async function configuration() {
-  // No-op by default
-}

--- a/src/handlers/index.js
+++ b/src/handlers/index.js
@@ -2,7 +2,7 @@ export { default as analytics } from './analytics';
 export { default as authentication } from './authentication';
 export { default as beforeInit } from './beforeInit';
 export { default as beforeReady } from './beforeReady';
-export { default as configuration } from './configuration';
+export { default as loadConfig } from './loadConfig';
 export { default as error } from './error';
 export { default as i18n } from './i18n';
 export { default as logging } from './logging';

--- a/src/handlers/loadConfig.js
+++ b/src/handlers/loadConfig.js
@@ -1,0 +1,3 @@
+export default async function loadConfig() {
+  // No-op by default
+}

--- a/src/handlers/loadConfig.test.js
+++ b/src/handlers/loadConfig.test.js
@@ -1,9 +1,9 @@
-import configuration from './configuration';
+import loadConfig from './loadConfig';
 
 it('should do nothing to the app', () => {
   const app = {};
 
-  configuration(app);
+  loadConfig(app);
 
   expect(app).toEqual({});
 });

--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,7 @@ export { default as analytics } from './handlers/analytics';
 export { default as authentication } from './handlers/authentication';
 export { default as beforeInit } from './handlers/beforeInit';
 export { default as beforeReady } from './handlers/beforeReady';
-export { default as configuration } from './handlers/configuration';
+export { default as loadConfig } from './handlers/loadConfig';
 export { default as error } from './handlers/error';
 export { default as i18n } from './handlers/i18n';
 export { default as logging } from './handlers/logging';


### PR DESCRIPTION
BREAKING CHANGE: The “configuration” phase has been renamed to “loadConfig” to be clearer.  The event constant `APP_CONFIGURED` has been changed to `APP_CONFIG_LOADED`