### PR TITLE
feat: replacing requireConfig with ensureConfig

### DIFF
--- a/docs/API.rst
+++ b/docs/API.rst
@@ -171,7 +171,7 @@ Note: By default, ``App.config`` is available to be used *immediately*,
 even before ``App.initialize`` is called. This is because environment
 variable-based config (using process.env) is statically linked into the
 application and so is available as soon as the code is loaded by the
-browser. See additional notes under ``App.requireConfig`` below.
+browser. See additional notes under ``App.ensureConfig`` below.
 
 .. _appapiclient:
 
@@ -197,38 +197,36 @@ Phases". There are constants for all the event types:
 
 .. _apprequireconfigkeys-requester:
 
-``App.requireConfig(keys, requester)``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``App.mergeConfig(newConfig, requester)``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Merges additional configuration values into ``App.config``.  Will override any values that exist with the same keys.
+
+::
+
+   App.mergeConfig({
+     NEW_KEY: 'new value',
+     OTHER_NEW_KEY: 'other new value',
+   }, 'MySpecialComponent');
+
+If any of the key values are ``undefined``, an error will be thrown.
+
+``App.ensureConfig(keys, requester)``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 A method allowing application code to indicate that particular
 ``App.config`` keys are required for them to function. Requester is for
 informational/error reporting purposes only.
 
-The method returns the required config values.
-
 ::
 
-   const config = App.requireConfig(['LMS_BASE_URL', 'LOGIN_URL'], 'MySpecialComponent');
+   App.ensureConfig(['LMS_BASE_URL', 'LOGIN_URL'], 'MySpecialComponent');
 
    // Will throw an error with:
    // "App configuration error: LOGIN_URL is required by MySpecialComponent."
    // if LOGIN_URL is undefined, for example.
 
-**NOTE**: If you use a custom handler for the ``loadConfig`` phase,
-be mindful of when you call ``App.requireConfig``. Normally, environment
-variable configuration is available immediately before
-``App.initialize`` is even called because it's statically linked into
-the app. If you load additional configuration at runtime (via the ``loadConfig`` phase), it won't be
-available until the ``APP_CONFIG_LOADED`` event is published:
-
-::
-
-   let config = null;
-   App.subscribe(APP_CONFIG_LOADED, () => {
-     config = App.requireConfig(['DYNAMICALLY_CONFIGURED_URL'], 'Consumer of custom config');
-
-     // Dynamic config is known to be set here.
-   });
+**NOTE**: ``App.ensureConfig`` waits until ``APP_CONFIG_LOADED`` is published to verify the existence of the specified properties.  If you use one of the properties prior to ``APP_CONFIG_LOADED``, then there is no guarantee that it's been loaded.
 
 .. _appqueryparams:
 
@@ -266,7 +264,7 @@ This will provide the following to HelloWorld:
    property is passed to ``AppProvider``.
 -  A ``Router`` for react-router.
 
-\`AppContext`\`
+``AppContext``
 ---------------
 
 ``AppContext`` provides data from ``App`` in a way that React components

--- a/example/ExamplePage.jsx
+++ b/example/ExamplePage.jsx
@@ -2,8 +2,17 @@ import React, { Component } from 'react';
 import { injectIntl } from '@edx/frontend-i18n';
 import { logInfo } from '@edx/frontend-logging';
 
+import App from '../dist/App';
 import AppContext from '../dist/AppContext';
 import messages from './messages';
+
+App.ensureConfig([
+  'EXAMPLE_VAR'
+]);
+
+App.mergeConfig({
+  EXAMPLE_VAR: process.env.EXAMPLE_VAR
+}, 'ExamplePage');
 
 class ExamplePage extends Component {
   constructor(props, context) {
@@ -18,6 +27,7 @@ class ExamplePage extends Component {
         <h1>{this.context.config.SITE_NAME} example page.</h1>
         <p>{this.props.intl.formatMessage(messages['example.message'])}</p>
         <p>Authenticated Username: {this.context.authenticatedUser.username}</p>
+        <p>EXAMPLE_VAR env var came through: {App.config.EXAMPLE_VAR}</p>
       </div>
     )
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1360,9 +1360,9 @@
       }
     },
     "@edx/frontend-i18n": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-i18n/-/frontend-i18n-3.0.2.tgz",
-      "integrity": "sha512-K0jdSjwM3jO76HL3Dn8oGb15/40yr2IMcz5PVrHx7dxi6bvg9cWBf7C5Zbq4bZ515ZTUbZLrPMDk61lFkmcUzQ==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-i18n/-/frontend-i18n-3.0.3.tgz",
+      "integrity": "sha512-1oBPba9xd/GK0hSBPhTdNGtHA+76j8sWJxRD9gQ+GsHLHF7Z75GsX+Ls6pB+fTNi9tjqaVWQLsA9rMGcj92hqQ==",
       "dev": true,
       "requires": {
         "@cospired/i18n-iso-languages": "2.0.2",
@@ -9933,11 +9933,6 @@
       "resolved": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.6.1.tgz",
       "integrity": "sha1-0uPuv/DZ05rVD1y9G1KnvOa7YRs=",
       "dev": true
-    },
-    "lodash.pick": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
-      "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM="
     },
     "lodash.set": {
       "version": "4.3.2",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint": "eslint --ext .js --ext .jsx .",
     "prepublishOnly": "npm run build",
     "semantic-release": "semantic-release",
-    "start": "parcel ./example/index.html --no-source-maps --out-dir example/dist",
+    "start": "EXAMPLE_VAR=\"Example Value\" parcel ./example/index.html --no-source-maps --out-dir example/dist",
     "test": "jest --coverage --passWithNoTests"
   },
   "husky": {
@@ -44,7 +44,7 @@
     "@commitlint/prompt-cli": "8.1.0",
     "@edx/frontend-analytics": "3.0.0",
     "@edx/frontend-auth": "7.0.1",
-    "@edx/frontend-i18n": "3.0.2",
+    "@edx/frontend-i18n": "3.0.3",
     "@edx/frontend-logging": "3.0.1",
     "@edx/paragon": "7.1.3",
     "babel-eslint": "10.0.3",
@@ -75,7 +75,6 @@
     "history": "4.9.0",
     "lodash.memoize": "4.1.2",
     "lodash.merge": "4.6.2",
-    "lodash.pick": "4.4.0",
     "pubsub-js": "1.7.0",
     "redux-devtools-extension": "2.13.8",
     "redux-logger": "3.0.6",
@@ -84,7 +83,7 @@
   "peerDependencies": {
     "@edx/frontend-analytics": "^3.0.0",
     "@edx/frontend-auth": "^7.0.1",
-    "@edx/frontend-i18n": "^3.0.2",
+    "@edx/frontend-i18n": "^3.0.3",
     "@edx/frontend-logging": "^3.0.1",
     "@edx/paragon": "^7.1.3",
     "prop-types": "^15.7.2",

--- a/src/getQueryParameters.test.js
+++ b/src/getQueryParameters.test.js
@@ -1,0 +1,25 @@
+import getQueryParameters from './getQueryParameters';
+
+describe('getQueryParameters', () => {
+  it('should use window location by default', () => {
+    expect(global.location.search).toEqual('');
+    expect(getQueryParameters()).toEqual({});
+  });
+
+  it('should make an empty object with no query string', () => {
+    expect(getQueryParameters('')).toEqual({});
+  });
+
+  it('should make an object with one key value pair', () => {
+    expect(getQueryParameters('?foo=bar')).toEqual({
+      foo: 'bar',
+    });
+  });
+
+  it('should make an object with one key value pair', () => {
+    expect(getQueryParameters('?foo=bar&baz=1')).toEqual({
+      foo: 'bar',
+      baz: '1',
+    });
+  });
+});


### PR DESCRIPTION
BREAKING CHANGE: requireConfig has been removed.  It has been replaced with ensureConfig, which will throw an exception after APP_CONFIG_LOADED if the specified properties don’t exist.  requireConfig was not useful for requiring custom configuration because there was no guarantee it would run late enough to see the config.

Also adding tests for getQueryParameters, and updating frontend-i18n.