### PR TITLE
feat: call frontend-analytics identifyAuthenticatedUser, sendPageEvent

### DIFF
--- a/docs/API.rst
+++ b/docs/API.rst
@@ -477,7 +477,7 @@ beforeReady
 
 Event constant: ``APP_BEFORE_READY``
 
-The ``beforeReady`` phase has no default behavior.
+The ``beforeReady`` phase calls ``identifyAuthenticatedUser`` and ``sendPageEvent`` from @edx/frontend-analytics, establishing that the page has been initialized for a specific user.
 
 ready
 ~~~~~

--- a/src/handlers/beforeReady.js
+++ b/src/handlers/beforeReady.js
@@ -1,3 +1,9 @@
-export default async function beforeReady() {
-  // No-op by default
+import {
+  identifyAuthenticatedUser,
+  sendPageEvent,
+} from '@edx/frontend-analytics';
+
+export default async function beforeReady(app) {
+  identifyAuthenticatedUser(app.authenticatedUser.userId);
+  sendPageEvent();
 }

--- a/src/handlers/beforeReady.test.js
+++ b/src/handlers/beforeReady.test.js
@@ -1,9 +1,28 @@
+import { identifyAuthenticatedUser, sendPageEvent } from '@edx/frontend-analytics';
+
 import beforeReady from './beforeReady';
 
+jest.mock('@edx/frontend-analytics', () => ({
+  identifyAuthenticatedUser: jest.fn(),
+  sendPageEvent: jest.fn(),
+}));
+
 it('should do nothing to the app', () => {
-  const app = {};
+  const app = {
+    authenticatedUser: {
+      userId: 12345,
+    },
+  };
 
   beforeReady(app);
 
-  expect(app).toEqual({});
+  expect(identifyAuthenticatedUser).toHaveBeenCalledWith(12345);
+  expect(sendPageEvent).toHaveBeenCalled();
+
+  // App should be unchanged.
+  expect(app).toEqual({
+    authenticatedUser: {
+      userId: 12345,
+    },
+  });
 });


### PR DESCRIPTION
The beforeReady phase now makes calls to identifyAuthenticatedUser and sendPageEvent, establishing that the page has been loaded for a specific user.