### PR TITLE
feat: upgrade frontend-auth with anonymous access capability

### DIFF
--- a/docs/API.rst
+++ b/docs/API.rst
@@ -495,7 +495,7 @@ Event constant: ``APP_AUTHENTICATED``
 
 The ``authentication`` phase creates an authenticated apiClient and
 makes it available at ``App.apiClient`` on the ``App`` singleton. It
-also runs ``ensureAuthenticatedUser`` from @edx/frontend-auth and will
+also runs ``getAuthenticatedUser`` from @edx/frontend-auth and will
 redirect to the login experience if the user does not have a valid
 authentication cookie. Finally, it will make authenticated user
 information available at ``App.authenticatedUser`` for later use by the

--- a/docs/API.rst
+++ b/docs/API.rst
@@ -498,8 +498,8 @@ makes it available at ``App.apiClient`` on the ``App`` singleton. It
 also runs ``ensureAuthenticatedUser`` from @edx/frontend-auth and will
 redirect to the login experience if the user does not have a valid
 authentication cookie. Finally, it will make authenticated user
-information available at ``App.authenticatedUser`` and
-``App.decodedAccessToken`` for later use by the application.
+information available at ``App.authenticatedUser`` for later use by the
+application.
 
 Default behavior is to redirect to a login page during this phase if the
 user is not authenticated. This effectively means that the library does

--- a/docs/API.rst
+++ b/docs/API.rst
@@ -497,7 +497,8 @@ The ``authentication`` phase creates an authenticated apiClient and
 makes it available at ``App.apiClient`` on the ``App`` singleton. It
 also runs ``getAuthenticatedUser`` from @edx/frontend-auth and will
 redirect to the login experience if the user does not have a valid
-authentication cookie. Finally, it will make authenticated user
+authentication cookie and the ``requireAuthenticatedUser``
+option is set to true. Finally, it will make authenticated user
 information available at ``App.authenticatedUser`` for later use by the
 application.
 

--- a/example/index.jsx
+++ b/example/index.jsx
@@ -24,6 +24,6 @@ App.subscribe(APP_ERROR, (error) => {
 
 App.initialize({
   messages: [],
-  requireAuthenticatedUser: true,
+  requireAuthenticatedUser: false,
   hydrateAuthenticatedUser: true,
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1256,12 +1256,11 @@
       }
     },
     "@edx/frontend-auth": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-auth/-/frontend-auth-7.0.1.tgz",
-      "integrity": "sha512-oElicVn8fbSAPEc79ivObiYgRTv62aNXP8y+utGBHQCNDi6N7bA4hXcKLjvz25hExmlzJdIR4v5IOLZiVMB5VQ==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-auth/-/frontend-auth-9.0.0.tgz",
+      "integrity": "sha512-nsJ0uAioV1JlZ5LsqaEoD1a5Hdp9WFzCT6HpyVW1LxVuu554G2s6EQtIDdogu0AE2wWPykfKNPYuEq/YT19EFA==",
       "dev": true,
       "requires": {
-        "@edx/frontend-logging": "^2.0.1",
         "axios": "^0.18.1",
         "camelcase-keys": "^5.0.0",
         "jwt-decode": "^2.2.0",
@@ -1271,12 +1270,6 @@
         "url-parse": "^1.4.3"
       },
       "dependencies": {
-        "@edx/frontend-logging": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/@edx/frontend-logging/-/frontend-logging-2.1.0.tgz",
-          "integrity": "sha512-IN0Bgh0/1Ax3TMPfZztqzdJchW4B5Px9PT4V9uu6TMj2Cj8el1CV3jrSA4Idg8C3CAkFZ/EHjmaFVCxgJ9aXVA==",
-          "dev": true
-        },
         "camelcase": {
           "version": "5.3.1",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
@@ -4791,9 +4784,9 @@
       }
     },
     "convert-source-map": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
-      "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
+      "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
       "dev": true,
       "requires": {
         "safe-buffer": "~5.1.1"
@@ -6020,9 +6013,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.303",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.303.tgz",
-      "integrity": "sha512-xDFPmMjJ0gQBsVwspB0bjcbFn3MVcvU0sxXYmh1UMbZ6rDogQVM3vSyOvTO4rym1KlnJIU6nqzK3qs0yKudmjw==",
+      "version": "1.3.304",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.304.tgz",
+      "integrity": "sha512-a5mqa13jCdBc+Crgk3Gyr7vpXCiFWfFq23YDCEmrPYeiDOQKZDVE6EX/Q4Xdv97n3XkcjiSBDOY0IS19yP2yeA==",
       "dev": true
     },
     "elliptic": {
@@ -6565,12 +6558,6 @@
           "requires": {
             "ansi-regex": "^4.1.0"
           }
-        },
-        "type-fest": {
-          "version": "0.5.2",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.5.2.tgz",
-          "integrity": "sha512-DWkS49EQKVX//Tbupb9TFa19c7+MK1XmzkrZUR8TAktmE/DizXoaoJV6TZ/tSIPXipqNiRI6CyAe7x69Jb6RSw==",
-          "dev": true
         }
       }
     },
@@ -9647,6 +9634,12 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
           "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+          "dev": true
+        },
+        "type-fest": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+          "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
           "dev": true
         }
       }
@@ -15868,6 +15861,15 @@
             }
           }
         },
+        "convert-source-map": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
+          "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.1"
+          }
+        },
         "postcss": {
           "version": "7.0.14",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
@@ -18231,9 +18233,9 @@
       }
     },
     "type-fest": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
-      "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.5.2.tgz",
+      "integrity": "sha512-DWkS49EQKVX//Tbupb9TFa19c7+MK1XmzkrZUR8TAktmE/DizXoaoJV6TZ/tSIPXipqNiRI6CyAe7x69Jb6RSw==",
       "dev": true
     },
     "type-is": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1256,18 +1256,16 @@
       }
     },
     "@edx/frontend-auth": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-auth/-/frontend-auth-9.0.0.tgz",
-      "integrity": "sha512-nsJ0uAioV1JlZ5LsqaEoD1a5Hdp9WFzCT6HpyVW1LxVuu554G2s6EQtIDdogu0AE2wWPykfKNPYuEq/YT19EFA==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-auth/-/frontend-auth-9.0.1.tgz",
+      "integrity": "sha512-1LzvioY1Lg52IzqNpoE/HqW2JwJR4OVO3tkQRLEDhgkzskd+qJTSfj4WL0Zmicho8OLckHKlU5bqUd9r1Vi3hA==",
       "dev": true,
       "requires": {
         "axios": "^0.18.1",
         "camelcase-keys": "^5.0.0",
         "jwt-decode": "^2.2.0",
-        "pubsub-js": "^1.7.0",
         "snakecase-keys": "^2.1.0",
-        "universal-cookie": "^3.0.4",
-        "url-parse": "^1.4.3"
+        "universal-cookie": "^3.0.4"
       },
       "dependencies": {
         "camelcase": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@commitlint/prompt": "8.1.0",
     "@commitlint/prompt-cli": "8.1.0",
     "@edx/frontend-analytics": "3.0.0",
-    "@edx/frontend-auth": "7.0.1",
+    "@edx/frontend-auth": "9.0.0",
     "@edx/frontend-build": "1.3.1",
     "@edx/frontend-i18n": "3.0.3",
     "@edx/frontend-logging": "3.0.1",
@@ -67,7 +67,7 @@
   },
   "peerDependencies": {
     "@edx/frontend-analytics": "^3.0.0",
-    "@edx/frontend-auth": "^7.0.1",
+    "@edx/frontend-auth": "^9.0.0",
     "@edx/frontend-i18n": "^3.0.3",
     "@edx/frontend-logging": "^3.0.1",
     "@edx/paragon": "^7.1.3",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@commitlint/prompt": "8.1.0",
     "@commitlint/prompt-cli": "8.1.0",
     "@edx/frontend-analytics": "3.0.0",
-    "@edx/frontend-auth": "9.0.0",
+    "@edx/frontend-auth": "9.0.1",
     "@edx/frontend-build": "1.3.1",
     "@edx/frontend-i18n": "3.0.3",
     "@edx/frontend-logging": "3.0.1",

--- a/src/AuthenticatedRoute.test.jsx
+++ b/src/AuthenticatedRoute.test.jsx
@@ -2,17 +2,20 @@ import React from 'react';
 import { mount } from 'enzyme';
 import { Router, Route } from 'react-router-dom';
 import { createBrowserHistory } from 'history';
+import { redirectToLogin } from '@edx/frontend-auth';
 
 import AuthenticatedRoute from './AuthenticatedRoute';
 import App from './App';
 import AppContext from './AppContext';
 
+jest.mock('@edx/frontend-auth', () => ({
+  redirectToLogin: jest.fn(),
+}));
+
 describe('AuthenticatedRoute', () => {
   beforeEach(() => {
-    App.apiClient = {
-      login: jest.fn(),
-    };
     App.history = createBrowserHistory();
+    redirectToLogin.mockReset();
   });
 
   it('should call login if not authenticated', () => {
@@ -29,7 +32,7 @@ describe('AuthenticatedRoute', () => {
     App.history.push('/authenticated');
     mount(component);
 
-    expect(App.apiClient.login).toHaveBeenCalledWith('http://localhost/authenticated');
+    expect(redirectToLogin).toHaveBeenCalledWith('http://localhost/authenticated');
   });
 
   it('should not call login if not the current route', () => {
@@ -46,7 +49,7 @@ describe('AuthenticatedRoute', () => {
     App.history.push('/');
     const wrapper = mount(component);
 
-    expect(App.apiClient.login).not.toHaveBeenCalled();
+    expect(redirectToLogin).not.toHaveBeenCalled();
     const element = wrapper.find('p');
     expect(element.text()).toEqual('Anonymous'); // This is just a sanity check on our setup.
   });
@@ -64,7 +67,7 @@ describe('AuthenticatedRoute', () => {
     );
     App.history.push('/authenticated');
     const wrapper = mount(component);
-    expect(App.apiClient.login).not.toHaveBeenCalled();
+    expect(redirectToLogin).not.toHaveBeenCalled();
     const element = wrapper.find('p');
     expect(element.text()).toEqual('Authenticated');
   });

--- a/src/data/service.js
+++ b/src/data/service.js
@@ -1,3 +1,4 @@
+import { redirectToLogin } from '@edx/frontend-auth';
 import App from '../App';
 import { camelCaseObject } from '../api';
 
@@ -18,5 +19,5 @@ function breakOnRedirectFromLogin() {
 
 export function loginRedirect() {
   breakOnRedirectFromLogin();
-  App.apiClient.login(global.location.href);
+  redirectToLogin(global.location.href);
 }

--- a/src/handlers/authentication.js
+++ b/src/handlers/authentication.js
@@ -1,14 +1,12 @@
 /* eslint-disable no-param-reassign */
-import { getAuthenticatedAPIClient } from '@edx/frontend-auth';
+import { getAuthenticatedApiClient, getAuthenticatedUser } from '@edx/frontend-auth';
 
 import { loginRedirect, getAuthenticatedUserAccount } from '../data/service';
 
 export default async function authentication(app) {
-  app.apiClient = getAuthenticatedAPIClient({
+  app.apiClient = getAuthenticatedApiClient({
     appBaseUrl: app.config.BASE_URL,
-    authBaseUrl: app.config.LMS_BASE_URL,
     accessTokenCookieName: app.config.ACCESS_TOKEN_COOKIE_NAME,
-    userInfoCookieName: app.config.USER_INFO_COOKIE_NAME,
     csrfTokenApiPath: app.config.CSRF_TOKEN_API_PATH,
     loginUrl: app.config.LOGIN_URL,
     logoutUrl: app.config.LOGOUT_URL,
@@ -16,17 +14,11 @@ export default async function authentication(app) {
     loggingService: app.loggingService,
   });
 
-  // NOTE: Remove this "attach" line once frontend-auth gets its own getAuthenticatedUser method.
-  // eslint-disable-next-line no-use-before-define
-  attachGetAuthenticatedUser(app.apiClient);
-
   // Get a valid access token for authenticated API access.
-  const { authenticatedUser, decodedAccessToken } =
-    await app.apiClient.getAuthenticatedUser(global.location.pathname);
+  const authenticatedUser = await getAuthenticatedUser();
 
   // Once we have refreshed our authentication, extract it for use later.
   app.authenticatedUser = authenticatedUser;
-  app.decodedAccessToken = decodedAccessToken;
 
   if (app.requireAuthenticatedUser && app.authenticatedUser === null) {
     loginRedirect();
@@ -37,73 +29,4 @@ export default async function authentication(app) {
       app.authenticatedUser = Object.assign({}, app.authenticatedUser, user);
     });
   }
-}
-
-// NOTE: Remove everything below here when frontend-auth gets its own getAuthenticatedUser method.
-/* istanbul ignore next */
-function getAuthenticatedUserFromDecodedAccessToken(decodedAccessToken) {
-  /* istanbul ignore next */
-  if (decodedAccessToken === null) {
-    throw new Error('Decoded access token is required to get authenticated user.');
-  }
-
-  return {
-    userId: decodedAccessToken.user_id,
-    username: decodedAccessToken.preferred_username,
-    roles: decodedAccessToken.roles ? decodedAccessToken.roles : [],
-    administrator: decodedAccessToken.administrator,
-  };
-}
-/* istanbul ignore next */
-function formatAuthenticatedResponse(decodedAccessToken) {
-  return {
-    authenticatedUser: getAuthenticatedUserFromDecodedAccessToken(decodedAccessToken),
-    decodedAccessToken,
-  };
-}
-/* istanbul ignore next */
-function attachGetAuthenticatedUser(httpClient) {
-  // Bail if there's a real implementation of getAuthenticatedUser
-  if (httpClient.getAuthenticatedUser !== undefined) {
-    return;
-  }
-
-  httpClient.getAuthenticatedUser = () =>
-    new Promise((resolve, reject) => {
-      // Validate auth-related cookies are in a consistent state.
-      const accessToken = httpClient.getDecodedAccessToken();
-      const tokenExpired = httpClient.isAccessTokenExpired(accessToken);
-      if (!tokenExpired) {
-        // We already have valid JWT cookies
-        resolve(formatAuthenticatedResponse(accessToken));
-      }
-      // Attempt to refresh the JWT cookies.
-      httpClient
-        .refreshAccessToken()
-        // Successfully refreshed the JWT cookies
-        .then((response) => {
-          const refreshedAccessToken = httpClient.getDecodedAccessToken();
-
-          if (refreshedAccessToken === null) {
-            // This should never happen, but it does. See ARCH-948 for past research into why.
-            const errorMessage = 'Access token is null after supposedly successful refresh.';
-            httpClient.loggingService.logError(`frontend-auth: ${errorMessage}`, {
-              previousAccessToken: accessToken,
-              axiosResponse: response,
-            });
-            reject(new Error(errorMessage));
-            return;
-          }
-
-          resolve(formatAuthenticatedResponse(refreshedAccessToken));
-        }).catch((e) => {
-          if (e.response.status === 401) {
-            return resolve({
-              authenticatedUser: null,
-              decodedAccessToken: null,
-            });
-          }
-          return reject(e);
-        });
-    });
 }


### PR DESCRIPTION
Use the new api offered by frontend auth.

BREAKING CHANGE: a breaking change of frontend-auth is required. App.apiClient no longer has methods login, logout, getDecodedAccessToken or refreshAccessToken. Refer to https://github.com/edx/frontend-auth/pull/82 for more info.