### PR TITLE
feat: add locale to AppContext

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,16 @@
+EXAMPLE_VAR=Example Value
+ACCESS_TOKEN_COOKIE_NAME=edx-jwt-cookie-header-payload
+BASE_URL=localhost:1995
+CREDENTIALS_BASE_URL=http://localhost:18150
+CSRF_TOKEN_API_PATH=/csrf/api/v1/token
+ECOMMERCE_BASE_URL=http://localhost:18130
+LANGUAGE_PREFERENCE_COOKIE_NAME=openedx-language-preference
+LMS_BASE_URL=http://localhost:18000
+LOGIN_URL=http://localhost:18000/login
+LOGOUT_URL=http://localhost:18000/login
+MARKETING_SITE_BASE_URL=http://localhost:18000
+ORDER_HISTORY_URL=localhost:1996/orders
+REFRESH_ACCESS_TOKEN_ENDPOINT=http://localhost:18000/login_refresh
+SEGMENT_KEY=ul
+SITE_NAME=Open edX
+USER_INFO_COOKIE_NAME=edx-user-info

--- a/src/App.js
+++ b/src/App.js
@@ -23,6 +23,9 @@ export const AUTHENTICATED_USER_CHANGED = `${AUTHENTICATED_USER_TOPIC}.CHANGED`;
 export const CONFIG_TOPIC = 'CONFIG';
 export const CONFIG_CHANGED = `${CONFIG_TOPIC}.CHANGED`;
 
+export const LOCALE_TOPIC = 'LOCALE';
+export const LOCALE_CHANGED = `${LOCALE_TOPIC}.CHANGED`;
+
 /* eslint no-underscore-dangle: "off" */
 export default class App {
   static _config = env;
@@ -126,6 +129,10 @@ export default class App {
 
   static unsubscribe(token) {
     PubSub.unsubscribe(token);
+  }
+
+  static publish(message, data) {
+    PubSub.publish(message, data);
   }
 
   static get queryParams() {

--- a/src/AppContext.jsx
+++ b/src/AppContext.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 const AppContext = React.createContext({
   authenticatedUser: null,
   config: {},
+  locale: null,
 });
 
 export default AppContext;

--- a/src/AppProvider.jsx
+++ b/src/AppProvider.jsx
@@ -5,7 +5,7 @@ import { Router } from 'react-router-dom';
 
 import OptionalReduxProvider from './OptionalReduxProvider';
 
-import App, { AUTHENTICATED_USER_CHANGED, CONFIG_CHANGED } from './App';
+import App, { AUTHENTICATED_USER_CHANGED, CONFIG_CHANGED, LOCALE_CHANGED } from './App';
 import ErrorBoundary from './ErrorBoundary';
 import AppContext from './AppContext';
 import { useAppEvent } from './data/hooks';
@@ -13,6 +13,7 @@ import { useAppEvent } from './data/hooks';
 const AppProvider = ({ store, children }) => {
   const [config, setConfig] = useState(App.config);
   const [authenticatedUser, setAuthenticatedUser] = useState(App.authenticatedUser);
+  const [locale, setLocale] = useState(getLocale());
 
   useAppEvent(AUTHENTICATED_USER_CHANGED, () => {
     setAuthenticatedUser(App.authenticatedUser);
@@ -22,12 +23,16 @@ const AppProvider = ({ store, children }) => {
     setConfig(App.config);
   });
 
+  useAppEvent(LOCALE_CHANGED, () => {
+    setLocale(getLocale());
+  });
+
   return (
     <ErrorBoundary>
       <AppContext.Provider
-        value={{ authenticatedUser, config }}
+        value={{ authenticatedUser, config, locale }}
       >
-        <IntlProvider locale={getLocale()} messages={getMessages()}>
+        <IntlProvider locale={locale} messages={getMessages()}>
           <OptionalReduxProvider store={store}>
             <Router history={App.history}>
               <React.Fragment>{children}</React.Fragment>

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,8 @@ export {
   AUTHENTICATED_USER_CHANGED,
   CONFIG_TOPIC,
   CONFIG_CHANGED,
+  LOCALE_TOPIC,
+  LOCALE_CHANGED,
 } from './App';
 
 export {


### PR DESCRIPTION
The AppContext now contains i18n locale data.  The value in AppContext should be identical to that returned by getLocale().

AppProvider will listen for LOCALE_CHANGED events and will update the locale accordingly.  At this time, frontend-i18n does NOT publish these events itself, as most applications don’t update the locale after page load.  Applications are responsible for publishing LOCALE_CHANGED if they update the locale.